### PR TITLE
fix typo (oauth3accesstoken → oauth2accesstoken)

### DIFF
--- a/articles/0235db4f33f182f5e39c.md
+++ b/articles/0235db4f33f182f5e39c.md
@@ -77,7 +77,7 @@ https://blog.container-solutions.com/using-google-container-registry-with-kubern
 ```
 kubectl create secret docker-registry gcr-access-token \
  --docker-server=gcr.io \
- --docker-username=oauth3accesstoken \
+ --docker-username=oauth2accesstoken \
  --docker-password="$(gcloud auth print-access-token)" \
  --docker-email=your-email@example.com
 ```


### PR DESCRIPTION
引用元の記事が間違っていると思うのですが、docker-registryのsecretを作成する際のユーザ名は`oauth3accesstoken`ではなく`oauth2accesstoken`ではないでしょうか？

ref: https://cloud.google.com/artifact-registry/docs/docker/authentication?hl=ja#token

実際に`oauth3accesstoken`を使用すると`kubectl describe po hoge`を使用した際に以下のようなエラーが出ます(一部をマスクしています)。

```txt
Events:
  Type     Reason     Age                  From               Message
  ----     ------     ----                 ----               -------
  Normal   Scheduled  2m15s                default-scheduler  Successfully assigned default/nginx-??? to minikube
  Normal   Pulling    50s (x4 over 2m15s)  kubelet            Pulling image "asia-northeast1-docker.pkg.dev/???/???/nginx:0.0.1"
  Warning  Failed     49s (x4 over 2m14s)  kubelet            Failed to pull image "asia-northeast1-docker.pkg.dev/???/???/nginx:0.0.1": Error response from daemon: Head "https://asia-northeast1-docker.pkg.dev/v2/???/???/nginx/manifests/0.0.1": denied: Unauthenticated request. Unauthenticated requests do not have permission "artifactregistry.repositories.downloadArtifacts" on resource "projects/???/locations/asia-northeast1/repositories/???" (or it may not exist)
  Warning  Failed     49s (x4 over 2m14s)  kubelet            Error: ErrImagePull
  Warning  Failed     22s (x6 over 2m13s)  kubelet            Error: ImagePullBackOff
  Normal   BackOff    9s (x7 over 2m13s)   kubelet            Back-off pulling image "asia-northeast1-docker.pkg.dev/???/???/nginx:0.0.1"
```